### PR TITLE
Switch to Docker deployment and update workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI & Deploy to Heroku (Buildpack)
+name: CI & Deploy to Heroku (Docker)
 
 on:
   push:
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # CI tests still run on the host (not inside Docker)
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -26,16 +27,18 @@ jobs:
       - name: Run tests
         run: ./gradlew test --no-daemon
 
-      #  Install Heroku CLI 
+      # ⬇️ Install Heroku CLI (optional — not required for Docker deploys)
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
 
-      # Deploy to Heroku 
-      - name: Deploy to Heroku
+      # 🚀 Deploy Docker image to Heroku (Dockerfile at repo root)
+      - name: Deploy Docker image to Heroku
         uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          usedocker: false
-          branch: main
+          usedocker: true
+          docker_heroku_process_type: web
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+# copy gradle wrapper + build files first to leverage Docker cache
+COPY gradlew gradlew.bat settings.gradle build.gradle ./
+COPY gradle gradle
+RUN chmod +x gradlew
+
+# copy source
+COPY src src
+
+# build the fat jar
+RUN ./gradlew bootJar --no-daemon
+
+# ---- Runtime stage ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+# (optional) JVM opts hook
+ENV JAVA_OPTS=""
+
+# copy jar from build stage
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+# Heroku provides $PORT; bind Spring to it
+CMD ["sh", "-c", "java $JAVA_OPTS -Dserver.port=$PORT -jar app.jar"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: java -Dserver.port=$PORT -jar build/libs/app.jar
-


### PR DESCRIPTION
I was having trouble getting Heroku to be able to access the jar file using a `Procfile`, so I switched to using a `Dockerfile` instead. The deployment to Heroku using a Dockerfile should work like it did using the Procfile, as I have done this same way of deploying before. This should also fix the issue of Heroku not being able to access the jar file. 