### PR TITLE
Implement GitHub OAuth callback to exchange code for access token

### DIFF
--- a/src/main/java/com/example/EventLink/controller/GithubAuthController.java
+++ b/src/main/java/com/example/EventLink/controller/GithubAuthController.java
@@ -18,13 +18,13 @@ import java.util.Map;
 @CrossOrigin(origins = "http://localhost:8081")
 public class GithubAuthController {
 
-    @Value("Ov23lihT7okuvIR1spoy")
+    @Value("${GITHUB_CLIENT_ID}")
     private String clientId;
 
-    @Value("8004c1bf0092d695b545ba3068fad58a32f701b0")
+    @Value("${GITHUB_CLIENT_SECRET}")
     private String clientSecret;
 
-    @Value("http://localhost:8081/HomePage")
+    @Value("${GITHUB_REDIRECT_URI}")
     private String redirectUri;
 
     private final JwtService jwtService;

--- a/src/main/java/com/example/EventLink/service/GitHubAuthService.java
+++ b/src/main/java/com/example/EventLink/service/GitHubAuthService.java
@@ -128,9 +128,9 @@ import java.util.Map;
 @Service
 public class GitHubAuthService {
 
-    private final String clientId = "Ov23lihT7okuvIR1spoy";
-    private final String clientSecret = "8004c1bf0092d695b545ba3068fad58a32f701b0";
-    private final String redirectUri = "http://localhost:8081/HomePage";
+    private final String clientId = "${GITHUB_CLIENT_ID}";
+    private final String clientSecret = "${GITHUB_CLIENT_SECRET}";
+    private final String redirectUri = "${GITHUB_REDIRECT_URI}";
 
     private final RestTemplate restTemplate = new RestTemplate();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,10 @@ google.client.secret=${GOOGLE_CLIENT_SECRET}
 google.redirect.uri=${GOOGLE_REDIRECT_URI:http://localhost:8080/login/oauth2/code/google}
 
 
+github.client.id=${GITHUB_CLIENT_ID}
+github.client.secret=${GITHUB_CLIENT_SECRET}
+github.redirect.uri=${GITHUB_REDIRECT_URI}
+
+
+
+


### PR DESCRIPTION
# Feature: GitHub OAuth Token Exchange

## Description
This pull request adds backend support for GitHub OAuth login. It implements a `/oauth2/callbackGithub` endpoint that:

1. Exchanges the authorization code received from the frontend for a GitHub access token.
2. Uses the access token to fetch the user's GitHub profile and email.
3. Generates a backend JWT for authenticated sessions.
4. Returns the user object (email, username, profile picture) along with the JWT to the frontend.

This enables the frontend to authenticate users via GitHub and securely manage sessions.

## Changes
- Added `GithubAuthController` with `callbackGithub` POST endpoint.
- Implemented code-to-token exchange using `RestTemplate`.
- Fetched GitHub user profile and primary email.
- Integrated JWT generation via `JwtService`.
- Returns structured response containing `token` and `user` object.

## Testing
- Tested OAuth flow locally with a GitHub test account.
- Verified access token retrieval, user info fetching, and JWT generation.
- Confirmed frontend receives correct user object and JWT.

**Note:** 
This implementation does not yet handle cases where a user logs in with both Google and GitHub using the same email. We still need to implement logic to correctly associate the login with the appropriate provider and retrieve the correct user account.
